### PR TITLE
Added missing type to root prim in the Teapot.

### DIFF
--- a/full_assets/Teapot/Teapot.usd
+++ b/full_assets/Teapot/Teapot.usd
@@ -9,7 +9,7 @@
     defaultPrim = "Teapot"
 )
 
-def "Teapot" (
+def Xform "Teapot" (
     assetInfo = {
         dictionary credits = {
             string FancyTeapot = "PolyHaven | Public Domain - CC0 | https://polyhaven.com/a/tea_set_01"


### PR DESCRIPTION
This missing root prim type causes unloaded payload extents to not draw at all. Note, that currently there is a separate regression in usdview, where unloaded payloads don't draw a bounding box. But this fix can be validated in Solaris.

In addition to logging the Hydra/Storm bug, will also log an issue to improve usdchecker to try and report these situations.