### PR TITLE
feat: adding the ability to generate thumbnails for directories

### DIFF
--- a/scripts/thumbnail-generator/README.md
+++ b/scripts/thumbnail-generator/README.md
@@ -5,15 +5,13 @@ Given a USD file, take a picture and assign it as it's thumbnail.
 
 ## Usage
 
-Single File Generation: `python generate_thumbnail.py <usd_file>`
-Generation for Entire Directory: `python generate_thumbnail.py <blank> --directory <directory>`
-Generation for Entire Directory and Recursive Child Folders: `python generate_thumbnail.py <blank> --directory <directory> --directory-recursive`
-
-positional arguments:
-  - `usd_file` :              The USD file you want to add a thumbnail to. If USDZ is input, a new USD file will be created to wrap the existing one called `<subject_usd_file>_Thumbnail.usd`, this is required by the script but ignored in the case that `--directory` is set.
+Single File Generation: `python generate_thumbnail.py --usd-file <usd_file>`
+Generation for Entire Directory: `python generate_thumbnail.py --directory <directory>`
+Generation for Entire Directory and Recursive Child Folders: `python generate_thumbnail.py --directory <directory> --recursive`
 
 optional arguments:
   - `-h`, `--help` :          Show help
+  - `--usd-file` :              The USD file you want to add a thumbnail to. If USDZ is input, a new USD file will be created to wrap the existing one called `<subject_usd_file>_Thumbnail.usd`
   - `--create-usdz-result` :  Returns the resulting files as a new USDZ file called `<subject_usd_file>_Thumbnail.usdz`
   - `--output-extension` :    The file extension of the output image you want (exr, png..). If using exr, make sure your USD install includes OpenEXR (exr is natively included in USD as of version 23.11)
   - `--verbose` :             Prints out the steps as they happen
@@ -23,7 +21,7 @@ optional arguments:
   - `--apply-thumbnail` :     Saves the image as the thumbnail for the given USD file.
   - `--render-purposes` :     A comma separated list of render purposes to include in the thumbnail. Valid values are: default, render, proxy, guide.
   - `--directory` :           A directory to generate thumbnails for all .usd, .usda, .usdc, and .usdz files. When a directory is supplied, usd-file is ignored.
-  - `--directory-recursive` : Will recursively search all directories underneath a given directory, requires a directory to be set.
+  - `--recursive` : Will recursively search all directories underneath a given directory, requires a directory to be set.
 
   Note: You must have usd installed and available in your path. [Install Steps Here](https://github.com/PixarAnimationStudios/OpenUSD#getting-and-building-the-code)
 

--- a/scripts/thumbnail-generator/README.md
+++ b/scripts/thumbnail-generator/README.md
@@ -5,22 +5,25 @@ Given a USD file, take a picture and assign it as it's thumbnail.
 
 ## Usage
 
-`python generate_thumbnail.py <usd_file>`
+Single File Generation: `python generate_thumbnail.py <usd_file>`
+Generation for Entire Directory: `python generate_thumbnail.py <blank> --directory <directory>`
+Generation for Entire Directory and Recursive Child Folders: `python generate_thumbnail.py <blank> --directory <directory> --directory-recursive`
 
 positional arguments:
-  - `usd_file` : The USD file you want to add a thumbnail to. If USDZ is input, a new USD file will be created to wrap the existing one called `<subject_usd_file>_Thumbnail.usd`
+  - `usd_file` :              The USD file you want to add a thumbnail to. If USDZ is input, a new USD file will be created to wrap the existing one called `<subject_usd_file>_Thumbnail.usd`, this is required by the script but ignored in the case that `--directory` is set.
 
 optional arguments:
-  - `-h`, `--help` : Show help
+  - `-h`, `--help` :          Show help
   - `--create-usdz-result` :  Returns the resulting files as a new USDZ file called `<subject_usd_file>_Thumbnail.usdz`
   - `--output-extension` :    The file extension of the output image you want (exr, png..). If using exr, make sure your USD install includes OpenEXR (exr is natively included in USD as of version 23.11)
   - `--verbose` :             Prints out the steps as they happen
   - `--dome-light` :          The path to the dome light HDR image to use, 
-  - `--width` :          The width of the image in pixels to generate. Default is 2048.
-
-  - `--height` :          The height of the image in pixels to generate. Default is 2048. If height is not specified, the image is square.
-  - `--apply-thumbnail`:    Saves the image as the thumbnail for the given USD file.
-  - `--render-purposes`:    A comma separated list of render purposes to include in the thumbnail. Valid values are: default, render, proxy, guide.
+  - `--width` :               The width of the image in pixels to generate. Default is 2048.
+  - `--height` :              The height of the image in pixels to generate. Default is 2048. If height is not specified, the image is square.
+  - `--apply-thumbnail` :     Saves the image as the thumbnail for the given USD file.
+  - `--render-purposes` :     A comma separated list of render purposes to include in the thumbnail. Valid values are: default, render, proxy, guide.
+  - `--directory` :           A directory to generate thumbnails for all .usd, .usda, .usdc, and .usdz files. When a directory is supplied, usd-file is ignored.
+  - `--directory-recursive` : Will recursively search all directories underneath a given directory, requires a directory to be set.
 
   Note: You must have usd installed and available in your path. [Install Steps Here](https://github.com/PixarAnimationStudios/OpenUSD#getting-and-building-the-code)
 
@@ -29,7 +32,7 @@ Given a USD file to use as the subject of the thumbnail do the following
 
 1. Generate a camera such that the subject is in view
 2. Sublayer the subject in the camera
-3. Run `usdrecord` to take a snapshot and store it in `/renders/<input>.png`
+3. Run `usdrecord` to take a snapshot and store it in `/thumbnails/<input>.png`
     - macOS
         - `usdrecord --camera ZCamera --imageWidth 2048 --renderer Metal camera.usda <input>.png` 
     - windows

--- a/scripts/thumbnail-generator/generate_thumbnail.py
+++ b/scripts/thumbnail-generator/generate_thumbnail.py
@@ -10,9 +10,9 @@ from pathlib import Path
 
 def parse_args():
     parser = argparse.ArgumentParser(description="This script takes a thumbnail image of the given USD file supplied and associates it with the file.")
-    parser.add_argument('usd_file', 
+    parser.add_argument('--usd-file', 
                         type=str, 
-                        help='The USD file you want to add a thumbnail to. If USDZ is input, a new USD file will be created to wrap the existing one called `<subject_usd_file>_Thumbnail.usd`, this is required by the script but ignored in the case that `--directory` is set.')
+                        help='The USD file you want to add a thumbnail to. If USDZ is input, a new USD file will be created to wrap the existing one called `<subject_usd_file>_Thumbnail.usd`')
     parser.add_argument('--dome-light',
                         type=str,
                         help='The path to the dome light HDR image to use, if any')
@@ -42,9 +42,8 @@ def parse_args():
                         default='default')
     parser.add_argument('--directory', 
                         type=str,
-                        help='A directory to generate thumbnails for all .usd, .usda, .usdc, and .usdz files. When a directory is supplied, usd-file is ignored.',
-                        default='default')
-    parser.add_argument('--directory-recursive', 
+                        help='A directory to generate thumbnails for all .usd, .usda, .usdc, and .usdz files. When a directory is supplied, usd-file is ignored.')
+    parser.add_argument('--recursive', 
                         action='store_true',
                         help='Will recursively search all directories underneath a given directory, requires a directory to be set.')
 
@@ -330,7 +329,7 @@ if __name__ == "__main__":
 
     args = parse_args()
 
-    if args.directory and args.directory_recursive:
+    if args.directory and args.recursive:
         for root, dirs, files in os.walk(args.directory):
             for file in files:
                 if file.endswith(EXTENSIONS):
@@ -349,6 +348,8 @@ if __name__ == "__main__":
                     generate_single_thumbnail(file_path, args)
                 except Exception as e:
                     print(f"Error processing {file_path}: {e}")
-    else:
+    elif args.usd_file:
         usd_file = args.usd_file
         generate_single_thumbnail(usd_file, args)
+    else:
+        print("Either --usd-file or --directory must be set.")


### PR DESCRIPTION
- added argument --directory to pass in a directory to generate thumbnails for all .usd, .usda, .usdc, .usdz files
- added argument --directory-recursive to do the same but for all directories under a given directory
- updated docs

Note: something messy here with this change is that <usd_file> is still required even if passing a directory in, is this okay? any better way to structure these arguments?