### PR TITLE
Skip missing .mtlx checks

### DIFF
--- a/.github/usdchecker.py
+++ b/.github/usdchecker.py
@@ -123,9 +123,7 @@ def main():
 
     # Skip 'missing' .mtlx documents, until usd-core includes UsdMtlX
     if failedChecks:
-      failedChecks = [check for check in failedChecks \
-                      if "MissingReferenceChecker" in check and \
-                      ".mtlx" not in check]
+        failedChecks = [check for check in failedChecks if '.mtlx' not in check]
     
     with _Stream(outFile, 'w') as ofp:
         

--- a/.github/usdchecker.py
+++ b/.github/usdchecker.py
@@ -120,6 +120,12 @@ def main():
     warnings = checker.GetWarnings()
     errors = checker.GetErrors()
     failedChecks = checker.GetFailedChecks()
+
+    # Skip 'missing' .mtlx documents, until usd-core includes UsdMtlX
+    if failedChecks:
+      failedChecks = [check for check in failedChecks \
+                      if "MissingReferenceChecker" in check and \
+                      ".mtlx" not in check]
     
     with _Stream(outFile, 'w') as ofp:
         


### PR DESCRIPTION
Until usd-core includes UsdMtlX, skip any 'missing reference' checks related to .mtlx documents.

Discussion raised in #82, would unblock PR #80