### PR TITLE
Adding MaterialX version of TextureCoordinateTest.

### DIFF
--- a/test_assets/TextureCoordinateTest/TextureCoordinateTest.mtlx
+++ b/test_assets/TextureCoordinateTest/TextureCoordinateTest.mtlx
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<materialx version="1.38" colorspace="lin_rec709">
+
+  <nodegraph name="TextureCoordinateTemplate_NodeGraph">
+    <image name="TextureCoordinateTemplate_Image" type="color3">
+      <input name="file" type="filename" value="TextureCoordinateTemplate.png" />
+    </image>
+    <output name="base_color_output" type="color3" nodename="TextureCoordinateTemplate_Image" />
+  </nodegraph>
+
+  <!-- BackPlaneMat -->
+  <standard_surface name="BackPlaneMat_Surface" type="surfaceshader">
+    <input name="base" type="float" value="1" />
+    <input name="base_color" type="color3" value="0.16000001, 0.16000001, 0.16000001" />
+    <input name="specular_roughness" type="float" value="1.0" />
+  </standard_surface>
+  <surfacematerial name="BackPlaneMat" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="BackPlaneMat_Surface" />
+  </surfacematerial>
+
+  <!-- BottomLeftMat -->
+  <standard_surface name="BottomLeftMat_Surface" type="surfaceshader">
+    <input name="base" type="float" value="1" />
+    <input name="base_color" type="color3" nodegraph="TextureCoordinateTemplate_NodeGraph" output="base_color_output"/>
+    <input name="specular_roughness" type="float" value="1.0" />
+  </standard_surface>
+  <surfacematerial name="BottomLeftMat" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="BottomLeftMat_Surface" />
+  </surfacematerial>
+
+  <!-- BottomRightMat -->
+  <standard_surface name="BottomRightMat_Surface" type="surfaceshader">
+    <input name="base" type="float" value="1" />
+    <input name="base_color" type="color3" nodegraph="TextureCoordinateTemplate_NodeGraph" output="base_color_output"/>
+    <input name="specular_roughness" type="float" value="1.0" />
+  </standard_surface>
+  <surfacematerial name="BottomRightMat" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="BottomRightMat_Surface" />
+  </surfacematerial>
+
+  <!-- TopLeftMat -->
+  <standard_surface name="TopLeftMat_Surface" type="surfaceshader">
+    <input name="base" type="float" value="1" />
+    <input name="base_color" type="color3" nodegraph="TextureCoordinateTemplate_NodeGraph" output="base_color_output"/>
+    <input name="specular_roughness" type="float" value="1.0" />
+  </standard_surface>
+  <surfacematerial name="TopLeftMat" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="TopLeftMat_Surface" />
+  </surfacematerial>
+
+  <!-- TopRightMat -->
+  <standard_surface name="TopRightMat_Surface" type="surfaceshader">
+    <input name="base" type="float" value="1" />
+    <input name="base_color" type="color3" nodegraph="TextureCoordinateTemplate_NodeGraph" output="base_color_output"/>
+    <input name="specular_roughness" type="float" value="1.0" />
+  </standard_surface>
+  <surfacematerial name="TopRightMat" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="TopRightMat_Surface" />
+  </surfacematerial>
+
+</materialx>

--- a/test_assets/TextureCoordinateTest/TextureCoordinateTestMaterialX.usda
+++ b/test_assets/TextureCoordinateTest/TextureCoordinateTestMaterialX.usda
@@ -1,0 +1,198 @@
+#usda 1.0
+(
+    defaultPrim = "Asset"
+    doc = "Converted from glTF with guc 0.2"
+    metersPerUnit = 1
+    upAxis = "Y"
+)
+
+def Xform "Asset" (
+    customData = {
+        string copyright = "Copyright 2017-2018 Analytical Graphics, Inc., CC-BY 4.0 https://creativecommons.org/licenses/by/4.0/ - Mesh and textures by Ed Mackey."
+        string generator = "guc conversion from Khronos Blender glTF 2.0 exporter, plus hand-edits"
+        string version = "2.0"
+    }
+    kind = "component"
+)
+{
+    def Scope "Materials"
+    {
+        def "MaterialX"
+        {
+            def Scope "Materials" (
+                prepend references = @./TextureCoordinateTest.mtlx@</MaterialX/Materials>
+            )
+            {
+            }
+        }
+    }
+
+    def Xform "Scenes"
+    {
+        def Xform "Scene"
+        {
+            def Xform "BackPlane"
+            {
+                def Xform "BackPlaneMesh"
+                {
+                    def Mesh "submesh" (
+                        prepend apiSchemas = ["MaterialBindingAPI"]
+                    )
+                    {
+                        uniform bool doubleSided = 1
+                        float3[] extent = [(-1.0, -1.0, -0.05), (1.0, 1.0, -0.05)]
+                        int[] faceVertexCounts = [3, 3]
+                        int[] faceVertexIndices = [0, 1, 2, 0, 3, 1]
+                        rel material:binding = </Asset/Materials/MaterialX/Materials/BackPlaneMat>
+                        normal3f[] normals = [(0.0, 0.0, -1.0), (0.0, 0.0, -1.0), (0.0, 0.0, -1.0), (0.0, 0.0, -1.0)] (
+                            interpolation = "vertex"
+                        )
+                        point3f[] points = [(-1.0, 1.0, -0.05), (1.0, -1.0, -0.05), (-1.0, -1.0, -0.05), (1.0, 1.0, -0.05)]
+                        color3f[] primvars:displayColor = [(0.16, 0.16, 0.16)] (
+                            customData = {
+                                dictionary guc = {
+                                    bool generated = 1
+                                }
+                            }
+                            interpolation = "constant"
+                        )
+                        uniform token subdivisionScheme = "none"
+                    }
+                }
+            }
+
+            def Xform "BottomRightObj"
+            {
+                def Xform "BottomRightMesh"
+                {
+                    def Mesh "submesh" (
+                        prepend apiSchemas = ["MaterialBindingAPI"]
+                    )
+                    {
+                        uniform bool doubleSided = 1
+                        float3[] extent = [(0.2, -1.2, 0.0), (1.2, -0.2, 0.0)]
+                        int[] faceVertexCounts = [3, 3]
+                        int[] faceVertexIndices = [0, 1, 2, 3, 1, 0]
+                        rel material:binding = </Asset/Materials/MaterialX/Materials/BottomRightMat>
+                        normal3f[] normals = [(0.0, 0.0, 1.0), (0.0, 0.0, 1.0), (0.0, 0.0, 1.0), (0.0, 0.0, 1.0)] (
+                            interpolation = "vertex"
+                        )
+                        point3f[] points = [(1.2, -1.2, 0.0), (0.2, -0.2, 0.0), (0.2, -1.2, 0.0), (1.2, -0.2, 0.0)]
+                        color3f[] primvars:displayColor = [(0, 0.8, 0)] (
+                            customData = {
+                                dictionary guc = {
+                                    bool generated = 1
+                                }
+                            }
+                            interpolation = "constant"
+                        )
+                        texCoord2f[] primvars:st = [(1.0, 0.0), (0.6, 0.4), (0.6, 0.0), (1.0, 0.4)] (
+                            interpolation = "vertex"
+                        )
+                        uniform token subdivisionScheme = "none"
+                    }
+                }
+            }
+
+            def Xform "BottomLeftObj"
+            {
+                def Xform "BottomLeftMesh"
+                {
+                    def Mesh "submesh" (
+                        prepend apiSchemas = ["MaterialBindingAPI"]
+                    )
+                    {
+                        uniform bool doubleSided = 1
+                        float3[] extent = [(-1.2, -1.2, 0.0), (-0.2, -0.2, 0.0)]
+                        int[] faceVertexCounts = [3, 3]
+                        int[] faceVertexIndices = [0, 1, 2, 3, 1, 0]
+                        rel material:binding = </Asset/Materials/MaterialX/Materials/BottomLeftMat>
+                        normal3f[] normals = [(0.0, 0.0, 1.0), (0.0, 0.0, 1.0), (0.0, 0.0, 1.0), (0.0, 0.0, 1.0)] (
+                            interpolation = "vertex"
+                        )
+                        point3f[] points = [(-0.2, -1.2, 0.0), (-1.2, -0.2, 0.0), (-1.2, -1.2, 0.0), (-0.2, -0.2, 0.0)]
+                        color3f[] primvars:displayColor = [(0, 0.16, 0.8)] (
+                            customData = {
+                                dictionary guc = {
+                                    bool generated = 1
+                                }
+                            }
+                            interpolation = "constant"
+                        )
+                        texCoord2f[] primvars:st = [(0.4, 0.0), (0.0, 0.4), (0.0, 0.0), (0.4, 0.4)] (
+                            interpolation = "vertex"
+                        )
+                        uniform token subdivisionScheme = "none"
+                    }
+                }
+            }
+
+            def Xform "TopRightObj"
+            {
+                def Xform "TopRightMesh"
+                {
+                    def Mesh "submesh" (
+                        prepend apiSchemas = ["MaterialBindingAPI"]
+                    )
+                    {
+                        uniform bool doubleSided = 1
+                        float3[] extent = [(0.2, 0.2, 0.0), (1.2, 1.2, 0.0)]
+                        int[] faceVertexCounts = [3, 3]
+                        int[] faceVertexIndices = [0, 1, 2, 3, 1, 0]
+                        rel material:binding = </Asset/Materials/MaterialX/Materials/TopRightMat>
+                        normal3f[] normals = [(0.0, 0.0, 1.0), (0.0, 0.0, 1.0), (0.0, 0.0, 1.0), (0.0, 0.0, 1.0)] (
+                            interpolation = "vertex"
+                        )
+                        point3f[] points = [(1.2, 0.2, 0.0), (0.2, 1.2, 0.0), (0.2, 0.2, 0.0), (1.2, 1.2, 0.0)]
+                        color3f[] primvars:displayColor = [(0.8, 0.08, 0)] (
+                            customData = {
+                                dictionary guc = {
+                                    bool generated = 1
+                                }
+                            }
+                            interpolation = "constant"
+                        )
+                        texCoord2f[] primvars:st = [(1.0, 0.6), (0.6, 1.0), (0.6, 0.6), (1.0, 1.0)] (
+                            interpolation = "vertex"
+                        )
+                        uniform token subdivisionScheme = "none"
+                    }
+                }
+            }
+
+            def Xform "TopLeftObj"
+            {
+                def Xform "TopLeftMesh"
+                {
+                    def Mesh "submesh" (
+                        prepend apiSchemas = ["MaterialBindingAPI"]
+                    )
+                    {
+                        uniform bool doubleSided = 1
+                        float3[] extent = [(-1.2, 0.2, 0.0), (-0.2, 1.2, 0.0)]
+                        int[] faceVertexCounts = [3, 3]
+                        int[] faceVertexIndices = [0, 1, 2, 3, 1, 0]
+                        rel material:binding = </Asset/Materials/MaterialX/Materials/TopLeftMat>
+                        normal3f[] normals = [(0.0, 0.0, 1.0), (0.0, 0.0, 1.0), (0.0, 0.0, 1.0), (0.0, 0.0, 1.0)] (
+                            interpolation = "vertex"
+                        )
+                        point3f[] points = [(-0.2, 0.2, 0.0), (-1.2, 1.2, 0.0), (-1.2, 0.2, 0.0), (-0.2, 1.2, 0.0)]
+                        color3f[] primvars:displayColor = [(0.8, 0.8, 0)] (
+                            customData = {
+                                dictionary guc = {
+                                    bool generated = 1
+                                }
+                            }
+                            interpolation = "constant"
+                        )
+                        texCoord2f[] primvars:st = [(0.4, 0.6), (0.0, 1.0), (0.0, 0.6), (0.4, 1.0)] (
+                            interpolation = "vertex"
+                        )
+                        uniform token subdivisionScheme = "none"
+                    }
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Thought it would be useful to have a MaterialX version of the TextureCoordinateTest,

It doesn't currently maintain the colors of the squares of the original, It looks like usdPreviewSurface naturally mutliplies in displayColor, not sure the best way to handle that in MaterialX.

* Adding TextureCoordinateTest.mtlx which includes simply references the included texture.
* Adding TextureCoordinateTestMaterialX.usda which is a copy of TextureCordinateTest.usda which references the mtlx, and has a little bit of cleanup.